### PR TITLE
Make engine compile as static library, fix linux compiling and fix `renderer.cpp` compiler warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,11 @@
 *.exe
 *.out
 *.app
+cbenginetest
 
 /include/glad
 /include/GLFW
 /include/KHR
 
 /src/glad.c
+bin/

--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,5 @@ cbenginetest
 /include/GLFW
 /include/KHR
 
-/src/glad.c
+lib/
 bin/

--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@ cbenginetest
 /include/GLFW
 /include/KHR
 
+/src/glad.c
 lib/
 bin/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,23 @@
-libraryTest:
-	g++ -c ./src/engine.cpp -O3 -Wall -Wno-missing-braces -I ./include/glad/ -I ./include/KHR/ -I ./include/GLFW/ -I ./include/ -L ./lib/ -lglfw3 -lglad -lopengl32 -lgdi32 -lwinmm
+SOURCES = src/engine.cpp src/input.cpp src/pixel.cpp src/renderer.cpp src/glad.c
+LIBTEST_SOURCES = src/main.cpp
 
-default:
-	g++ ./src/*.cpp ./src/*.c -o game.exe -O3 -Wall -Wno-missing-braces -I ./include/glad/ -I ./include/KHR/ -I ./include/GLFW/ -I ./include/ -L ./lib/ -lglfw3 -lglad -lopengl32 -lgdi32 -lwinmm
+CXX_FLAGS = -O3 -Wall -Wno-missing-braces -I ./include/glad/ -I ./include/KHR/ -I ./include/GLFW/ -I ./include/
+
+ifeq ($(OS),Windows_NT)
+	# Windows specific compile flags
+	CXX_FLAGS += -lopengl32 -lgdi32 -lwinmm -L ./lib/
+else
+	CXX_FLAGS += -lGL -lX11 -ldl
+endif
+
+CXX_FLAGS += -lglfw -lglad
+
+test: lib
+	g++ $(CXX_FLAGS) $(LIBTEST_SOURCES) libcbengine.a -o cbenginetest
+
+lib:
+	g++ -c -fPIC $(SOURCES) $(CXX_FLAGS)
+	ar rcs libcbengine.a *.o
+	rm *.o
+
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SOURCES = src/engine.cpp src/input.cpp src/pixel.cpp src/renderer.cpp lib/glad.c
+SOURCES = src/engine.cpp src/input.cpp src/pixel.cpp src/renderer.cpp src/glad.c
 LIBTEST_SOURCES = src/main.cpp
 
 LIB_OUT = libcbengine

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,41 @@
-SOURCES = src/engine.cpp src/input.cpp src/pixel.cpp src/renderer.cpp src/glad.c
+SOURCES = src/engine.cpp src/input.cpp src/pixel.cpp src/renderer.cpp lib/glad.c
 LIBTEST_SOURCES = src/main.cpp
 
-CXX_FLAGS = -O3 -Wall -Wno-missing-braces -I ./include/glad/ -I ./include/
+LIB_OUT = libcbengine
+LIB_EXT = .a
+LIBTEST_OUT = cbenginetest
+LIBTEST_EXT =
+
+CXX_FLAGS = -O3 -Wall -Wno-missing-braces -I ./lib/ -I ./include/
+CXX = g++
+
+# Only use if not on Windows but you need to compile for Windows
+ifdef TARGETWIN
+	ifneq ($(OS),Windows_NT)
+		OS = Windows_NT
+		CXX = x86_64-w64-mingw32-g++
+		CXX_FLAGS += -static -static-libgcc -static-libstdc++
+	endif
+endif
 
 ifeq ($(OS),Windows_NT)
 	# Windows specific compile flags
-	CXX_FLAGS += -I ./include/KHR/ -I ./include/GLFW/ -lopengl32 -lgdi32 -lwinmm -L ./lib/
+	CXX_FLAGS += -L ./lib/ -lglfw3 -lglfw3dll -lopengl32 -lgdi32 -lwinmm -luser32 -lkernel32
+	LIB_EXT = .lib
+	LIBTEST_EXT = .exe
+else ifeq ($(OS),Darwin)
+	CXX = clang++
+	CXX_FLAGS += $$(pkg-config --cflags glfw3) $$(pkg-config --libs glfw3)
 else
-	CXX_FLAGS += -lGL -lX11 -ldl
+	CXX_FLAGS += $$(pkg-config --cflags glfw3) $$(pkg-config --libs glfw3)
 endif
 
-CXX_FLAGS += -lglfw -lglad
+test: library
+	$(CXX) $(LIBTEST_SOURCES) $(LIB_OUT)$(LIB_EXT) -o $(LIBTEST_OUT)$(LIBTEST_EXT) $(CXX_FLAGS)
 
-test: lib
-	g++ $(CXX_FLAGS) $(LIBTEST_SOURCES) libcbengine.a -o cbenginetest
-
-lib:
-	g++ -c -fPIC $(SOURCES) $(CXX_FLAGS)
-	ar rcs libcbengine.a *.o
+library:
+	$(CXX) -c -fPIC $(SOURCES) $(CXX_FLAGS)
+	ar rcs $(LIB_OUT)$(LIB_EXT) *.o
 	rm *.o
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 SOURCES = src/engine.cpp src/input.cpp src/pixel.cpp src/renderer.cpp src/glad.c
 LIBTEST_SOURCES = src/main.cpp
 
-CXX_FLAGS = -O3 -Wall -Wno-missing-braces -I ./include/glad/ -I ./include/KHR/ -I ./include/GLFW/ -I ./include/
+CXX_FLAGS = -O3 -Wall -Wno-missing-braces -I ./include/glad/ -I ./include/
 
 ifeq ($(OS),Windows_NT)
 	# Windows specific compile flags
-	CXX_FLAGS += -lopengl32 -lgdi32 -lwinmm -L ./lib/
+	CXX_FLAGS += -I ./include/KHR/ -I ./include/GLFW/ -lopengl32 -lgdi32 -lwinmm -L ./lib/
 else
 	CXX_FLAGS += -lGL -lX11 -ldl
 endif

--- a/include/core.h
+++ b/include/core.h
@@ -6,7 +6,7 @@
 ///////////////////////////////////////////////
 
 #include "glad.h"
-#include "glfw3.h"
+#include <GLFW/glfw3.h>
 
 struct Core
 {

--- a/include/core.h
+++ b/include/core.h
@@ -5,7 +5,7 @@
 // Contains important core stuff for the engine
 ///////////////////////////////////////////////
 
-#include "glad.h"
+#include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
 struct Core

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -156,7 +156,7 @@ int Renderer::Init(void (&Start)() ,void (&Update)(float deltaTime))
     {
         glfwPollEvents();
 
-        if (&window != NULL)
+        if (window != NULL)
         {
             Update(deltaTime);
         }
@@ -229,7 +229,7 @@ void SetPixel(int x, int y, Pixel pixel)
 
 void FillScreen(uint_fast8_t r, uint_fast8_t g, uint_fast8_t b)
 {
-    for (int i = 0; i < sizeof(pixels); i+= 3)
+    for (long unsigned int i = 0; i < sizeof(pixels); i+= 3)
     {
         pixels[i] = r;
         pixels[i + 1] = g;

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -88,11 +88,6 @@ int Renderer::Init(void (&Start)() ,void (&Update)(float deltaTime))
     glDeleteShader(vertexShader);
     glDeleteShader(fragmentShader);
 
-    // Vertex buffer
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float),
-                            (void *)0);
-    glEnableVertexAttribArray(0);
-
     // Assign verticies
     float vertices[] = {
         // positions // colors // texture coords


### PR DESCRIPTION
These changes have been tested on Arch Linux. May need further modification for other OSes.