### PR TITLE
Typedefs for function pointers

### DIFF
--- a/include/core.h
+++ b/include/core.h
@@ -5,8 +5,8 @@
 // Contains important core stuff for the engine
 ///////////////////////////////////////////////
 
-#include "glad.h"
-#include "glfw3.h"
+#include <glad/glad.h>
+#include <GLFW/glfw3.h>
 
 typedef void (*StartFn) ();
 typedef void (*UpdateFn) (float deltaTime);

--- a/include/core.h
+++ b/include/core.h
@@ -8,6 +8,10 @@
 #include "glad.h"
 #include "glfw3.h"
 
+typedef void (*StartFn) ();
+typedef void (*UpdateFn) (float deltaTime);
+typedef void (*FinishFn) ();
+
 struct Core
 {
     static GLFWwindow *window;

--- a/include/engine.h
+++ b/include/engine.h
@@ -8,7 +8,7 @@
 
 //Engine functions
 
-void InitWindow(void (&Start)(), void (&Update)(float deltaTime), void (&Finish)());
+void InitWindow(StartFn start, UpdateFn update, FinishFn finish);
 void SetTitle(std::string windowTitle);
 void SetWindowSize(int size);
 void SetVsync(bool enabled);

--- a/include/renderer.h
+++ b/include/renderer.h
@@ -13,7 +13,7 @@
 class Renderer
 {
     public:
-        int Init(void(&Start)(), void (&Update)(float deltaTime));
+        int Init(StartFn start, UpdateFn update);
         void SetWindow(GLFWwindow *newWindow);
 
     private:

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1,11 +1,11 @@
 #include "engine.h"
 
-void InitWindow(void (&Start)(), void (&Update)(float deltaTime), void (&Finish)())
+void InitWindow(StartFn start, UpdateFn update, FinishFn finish)
 {
     Renderer renderer;
-    renderer.Init(Start, Update);
+    renderer.Init(start, update);
 
-    Finish();
+    finish();
 }
 
 void SetTitle(std::string title)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,7 @@ void Finish()
 //Init the engine here
 int main()
 {
-    InitWindow(Start, Update, Finish);
+    InitWindow(&Start, &Update, &Finish);
    
     return 0;
 }

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -11,7 +11,7 @@ GLFWwindow* Core::window;
 //The main pixel array
 GLubyte pixels[WIDTH * HEIGHT * 3]; // Array size is width * height * 3 (1 byte per channel)
 
-int Renderer::Init(void (&Start)() ,void (&Update)(float deltaTime))
+int Renderer::Init(StartFn start, UpdateFn update)
 {
     // Set up the main window
     glfwInit();
@@ -145,7 +145,7 @@ int Renderer::Init(void (&Start)() ,void (&Update)(float deltaTime))
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
     // Call the start function now everything is initialised 
-    Start();
+    start();
 
     // Time variables
     float lastTime = 0.0f;
@@ -158,7 +158,7 @@ int Renderer::Init(void (&Start)() ,void (&Update)(float deltaTime))
 
         if (&window != NULL)
         {
-            Update(deltaTime);
+            update(deltaTime);
         }
 
         glClearColor(0.0f, 0.0f, 0.0f, 1.0f);


### PR DESCRIPTION
C and C++ have a `typedef` keyword that allows us to assign identifiers to function pointers and types. That means whenever a function declaration may go from `void (*StartFn) ()` to for example, `std::vector<const char*>::iterator (*Start) ()`, only the typedef has to be changed. Not the references that use it. This saves both time and effort.